### PR TITLE
Implement Tarantool iproto hello world

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,0 +1,22 @@
+name: Build on linux
+
+on: [push, pull_request]
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ocaml/setup-ocaml@v3
+        with: 
+          ocaml-compiler: 5
+
+      - name: Install depedencies
+        run: opam install . --deps-only --with-test
+
+      - name: Format
+        run: opam exec -- dune fmt
+
+      - name: Build
+        run: opam exec -- dune build @check @all
+

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -7,11 +7,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - uses: ocaml/setup-ocaml@v3
         with: 
           ocaml-compiler: 5
 
-      - name: Install depedencies
+      - name: Install OCaml depedencies
         run: opam install . --deps-only --with-test
 
       - name: Format

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/tarantool-c"]
+	path = vendor/tarantool-c
+	url = https://github.com/tarantool/tarantool-c.git

--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,0 +1,5 @@
+profile = ocamlformat
+version = 0.27.0
+sequence-style = terminator
+match-indent = 2
+match-indent-nested = always

--- a/bin/dune
+++ b/bin/dune
@@ -1,4 +1,4 @@
 (executable
- (public_name tarantool_ml)
  (name main)
- (libraries tarantool_ml))
+ (public_name tarantool)
+ (libraries tarantool))

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1,1 +1,3 @@
+open Tarantool
+
 let () = print_endline "Hello, World!"

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1,3 +1,17 @@
 open Tarantool
 
-let () = print_endline "Hello, World!"
+let () =
+  let tnt =
+    Tnt.net
+      (Ctypes.coerce (Ctypes.ptr Ctypes.void) (Ctypes.ptr Tnt.stream)
+         Ctypes.null )
+  in
+  let _a = Tnt.set_string tnt Tnt.Uri "localhost:3301" in
+  let _b = Tnt.set_int tnt Tnt.SendBuf 0 in
+  let _c = Tnt.set_int tnt Tnt.RecvBuf 0 in
+  let _d = Tnt.connect tnt in
+  let _e = Tnt.ping tnt in
+  let reply = Tnt.reply_init Ctypes.null in
+  let f = Tnt.read_reply tnt reply in
+  if f == 0 then Format.printf "Ping success\n%!"
+  else Format.printf "Ping failed\n%!"

--- a/dune-project
+++ b/dune-project
@@ -1,6 +1,6 @@
 (lang dune 3.17)
 
-(name tarantool_ml)
+(name tarantool)
 
 (generate_opam_files true)
 
@@ -14,7 +14,7 @@
 (license BSD-3-Clause)
 
 (package
- (name tarantool_ml)
+ (name tarantool)
  (synopsis "Tarantool client for OCaml")
  (description "Tarantool client for OCaml")
  (depends ocaml)

--- a/dune-project
+++ b/dune-project
@@ -5,7 +5,7 @@
 (generate_opam_files true)
 
 (source
- (github username/reponame))
+ (github georgiy-belyanin/tarantool-ml))
 
 (authors "Georgiy Belyanin <belyaningeorge@ya.ru>")
 

--- a/dune-project
+++ b/dune-project
@@ -17,7 +17,18 @@
  (name tarantool)
  (synopsis "Tarantool client for OCaml")
  (description "Tarantool client for OCaml")
- (depends ocaml)
+ (depends
+  ocaml
+  ctypes
+  ctypes-foreign
+  ppx_deriving
+  (ppx_expect :with-test)
+  (ppx_inline_test :with-test)
+  (ocamlformat
+   (and
+    (= 0.27.0)
+    :dev))
+  )
  (tags
   ("dbms" "tarantool" )))
 

--- a/lib/Tnt.ml
+++ b/lib/Tnt.ml
@@ -1,0 +1,86 @@
+open Ctypes
+open Foreign
+
+type opt =
+  | Uri
+  | TmoutConnect
+  | TmoutRecv
+  | TmoutSend
+  | SendCb
+  | SendCbv
+  | SendCbArg
+  | SendBuf
+  | RecvCb
+  | RecvCbArg
+  | RecvBuf
+[@@deriving enum]
+
+let ssize_t = int64_t
+
+let request = void
+
+let reply = void
+
+type stream
+
+let stream = structure "tnt_stream"
+
+let ( -: ) ty label = field stream label ty
+
+let alloc = int -: "alloc"
+
+let write =
+  funptr (ptr stream @-> string @-> size_t @-> returning ssize_t) -: "write"
+
+let writev =
+  funptr (ptr stream @-> ptr void @-> int @-> returning ssize_t) -: "writev"
+
+let write_request =
+  funptr (ptr stream @-> ptr request @-> ptr uint64_t @-> returning ssize_t)
+  -: "write_request"
+
+let read =
+  funptr (ptr stream @-> ptr char @-> size_t @-> returning ssize_t) -: "read"
+
+let read_reply =
+  static_funptr (ptr stream @-> ptr reply @-> returning int) -: "read_reply"
+
+let free = funptr (ptr stream @-> returning void) -: "free"
+
+let data = ptr void -: "free"
+
+let wrcnt = uint32_t -: "data"
+
+let reqid = uint64_t -: "reqid"
+
+let () = seal (stream : stream structure typ)
+
+let net = foreign "tnt_net" (ptr stream @-> returning (ptr stream))
+
+let _set_string =
+  foreign "tnt_set" (ptr stream @-> int @-> string @-> returning int)
+
+let _set_int = foreign "tnt_set" (ptr stream @-> int @-> int @-> returning int)
+
+let _wrap_set set stream opt = set stream (opt_to_enum opt)
+
+let set_string = _wrap_set _set_string
+
+let set_int = _wrap_set _set_int
+
+let connect = foreign "tnt_connect" (ptr stream @-> returning int)
+
+let ping = foreign "tnt_ping" (ptr stream @-> returning int)
+
+let reply_init = foreign "tnt_reply_init" (ptr reply @-> returning (ptr reply))
+
+let reply_free = foreign "tnt_reply_free" (ptr reply @-> returning void)
+
+let read_reply tnt r =
+  let read_reply_f =
+    getf !@tnt read_reply
+    |> Ctypes.coerce
+         (static_funptr (ptr stream @-> ptr reply @-> returning int))
+         (funptr (ptr stream @-> ptr reply @-> returning int))
+  in
+  read_reply_f tnt r

--- a/lib/dune
+++ b/lib/dune
@@ -1,3 +1,7 @@
 (library
  (name tarantool)
- (public_name tarantool))
+ (public_name tarantool)
+ (modules Tnt)
+ (libraries ctypes ctypes-foreign)
+ (preprocess
+  (pps ppx_deriving.enum ppx_inline_test ppx_assert ppx_expect)))

--- a/lib/dune
+++ b/lib/dune
@@ -1,2 +1,3 @@
 (library
- (name tarantool_ml))
+ (name tarantool)
+ (public_name tarantool))

--- a/tarantool.opam
+++ b/tarantool.opam
@@ -11,6 +11,10 @@ bug-reports: "https://github.com/georgiy-belyanin/tarantool-ml/issues"
 depends: [
   "dune" {>= "3.17"}
   "ocaml"
+  "ctypes"
+  "ctypes-foreign"
+  "ppx_expect" {with-test}
+  "ppx_inline_test" {with-test}
   "odoc" {with-doc}
 ]
 build: [

--- a/tarantool.opam
+++ b/tarantool.opam
@@ -13,8 +13,10 @@ depends: [
   "ocaml"
   "ctypes"
   "ctypes-foreign"
+  "ppx_deriving"
   "ppx_expect" {with-test}
   "ppx_inline_test" {with-test}
+  "ocamlformat" {= "0.27.0" & dev}
   "odoc" {with-doc}
 ]
 build: [

--- a/tarantool_ml.opam
+++ b/tarantool_ml.opam
@@ -6,8 +6,8 @@ maintainer: ["Georgiy Belyanin <belyaningeorge@ya.ru>"]
 authors: ["Georgiy Belyanin <belyaningeorge@ya.ru>"]
 license: "BSD-3-Clause"
 tags: ["dbms" "tarantool"]
-homepage: "https://github.com/username/reponame"
-bug-reports: "https://github.com/username/reponame/issues"
+homepage: "https://github.com/georgiy-belyanin/tarantool-ml"
+bug-reports: "https://github.com/georgiy-belyanin/tarantool-ml/issues"
 depends: [
   "dune" {>= "3.17"}
   "ocaml"
@@ -27,4 +27,4 @@ build: [
     "@doc" {with-doc}
   ]
 ]
-dev-repo: "git+https://github.com/username/reponame.git"
+dev-repo: "git+https://github.com/georgiy-belyanin/tarantool-ml.git"


### PR DESCRIPTION
This patch implements basic iproto connection test. The app connects to
local Tarantool instance and pings it using Tarantool-c [^1] library
through FFI and `ocaml-ctypes` [^2] bindings.

Run Tarantool and configure it as follows.
```lua
box.cfg{listen = 'localhost:3301'}
```

Then run the app. The ping should be successful.

Note, `libffi` and `libtarantool` [^1] should be installed for the app
to be built.

[^1] https://github.com/tarantool/tarantool-c
[^2] https://github.com/yallop/ocaml-ctypes