### PR TITLE
Add request bindings

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -2,7 +2,18 @@ open Tnt
 
 let ( let* ) = Result.bind
 
-let connect_and_ping () =
+let connect_and_ping_request () =
+  let stream = Stream.net () in
+  let* () = Stream.set_string stream Opt.Uri "localhost:3301" in
+  let* () = Stream.set_int stream Opt.RecvBuf 0 in
+  let* () = Stream.set_int stream Opt.SendBuf 0 in
+  let* () = Stream.connect stream in
+  let request = Request.ping () in
+  let _ = Request.compile stream request in
+  let* _ = Stream.read_reply stream in
+  Result.ok ()
+
+let _connect_and_ping () =
   let stream = Stream.net () in
   let* () = Stream.set_string stream Opt.Uri "localhost:3301" in
   let* () = Stream.set_int stream Opt.RecvBuf 0 in
@@ -13,7 +24,7 @@ let connect_and_ping () =
   Result.ok ()
 
 let () =
-  match connect_and_ping () with
+  match connect_and_ping_request () with
     | Ok () ->
         Format.printf "Pinged!\n"
     | Error code ->

--- a/lib/tnt/dune
+++ b/lib/tnt/dune
@@ -1,7 +1,7 @@
 (library
  (name tnt)
  (public_name tnt)
- (modules opt reply stream tnt)
+ (modules opt reply request stream tnt)
  (libraries ctypes ctypes-foreign)
  (preprocess
   (pps ppx_deriving.enum ppx_inline_test ppx_assert ppx_expect)))

--- a/lib/tnt/reply.ml
+++ b/lib/tnt/reply.ml
@@ -11,7 +11,7 @@ let _free = foreign "tnt_reply_free" (ptr c_t @-> returning void)
 
 type t = Reply of c_t Ctypes_static.ptr
 
-let init () = Reply (_init Ctypes.null)
+let init () = Reply (_init null)
 
 let free (Reply r) = _free r
 

--- a/lib/tnt/request.ml
+++ b/lib/tnt/request.ml
@@ -1,0 +1,100 @@
+open Ctypes
+open Foreign
+
+type c_t = unit
+
+let c_t = Ctypes.void
+
+let _init = foreign "tnt_request_init" (ptr c_t @-> returning (ptr c_t))
+
+let _free = foreign "tnt_request_free" (ptr c_t @-> returning void)
+
+let _compile =
+  foreign "tnt_request_compile"
+    (ptr Stream.c_t @-> ptr c_t @-> returning int64_t)
+
+let _set_uint32 call =
+  foreign
+    (String.concat "" ["tnt_request_set_"; call])
+    (ptr c_t @-> uint32_t @-> returning int)
+
+let _set_stream call =
+  foreign
+    (String.concat "" ["tnt_request_set_"; call])
+    (ptr c_t @-> ptr Stream.c_t @-> returning int)
+
+let _set_string call =
+  foreign
+    (String.concat "" ["tnt_request_set_"; call])
+    (ptr c_t @-> string @-> returning int)
+
+let _ctor call =
+  foreign
+    (String.concat "" ["tnt_request_"; call])
+    (ptr c_t @-> returning (ptr c_t))
+
+type t = Request of c_t Ctypes_static.ptr
+
+let to_result ok code =
+  match code with 0 -> Result.ok ok | _ -> Result.error code
+
+let init () = Request (_init null)
+
+let free (Request r) = _free r
+
+let set_uint32 call (Request r) v = _set_uint32 call r v |> to_result ()
+
+let set_stream call (Request r) s =
+  _set_stream call r (Stream.c s) |> to_result ()
+
+let set_string call (Request r) v = _set_string call r v |> to_result ()
+
+let ctor call () =
+  let c = _ctor call null in
+  Request c
+
+let set_space = set_uint32 "space"
+
+let set_index = set_uint32 "index"
+
+let set_offset = set_uint32 "offset"
+
+let set_limit = set_uint32 "limit"
+
+let set_index_base = set_uint32 "index_base"
+
+let set_key = set_stream "key"
+
+let set_tuple = set_stream "tuple"
+
+let set_ops = set_stream "ops"
+
+let set_func = set_string "func"
+
+let set_expr = set_string "expr"
+
+let compile s (Request r) = _compile (Stream.c s) r
+
+let select = ctor "select"
+
+let insert = ctor "insert"
+
+let replace = ctor "replace"
+
+let update = ctor "update"
+
+let delete = ctor "delete"
+
+let auth = ctor "auth"
+
+let eval = ctor "eval"
+
+let call = ctor "call"
+
+let call_16 = ctor "call_16"
+
+let upsert = ctor "upsert"
+
+let ping = ctor "ping"
+
+let c (Request r) = r

--- a/lib/tnt/request.mli
+++ b/lib/tnt/request.mli
@@ -1,0 +1,55 @@
+type t
+
+val init : unit -> t
+
+val free : t -> unit
+
+val set_space : t -> Unsigned.UInt32.t -> (unit, int) Result.t
+
+val set_index : t -> Unsigned.UInt32.t -> (unit, int) Result.t
+
+val set_offset : t -> Unsigned.UInt32.t -> (unit, int) Result.t
+
+val set_limit : t -> Unsigned.UInt32.t -> (unit, int) Result.t
+
+val set_index_base : t -> Unsigned.UInt32.t -> (unit, int) Result.t
+
+val set_key : t -> Stream.t -> (unit, int) Result.t
+
+val set_func : t -> string -> (unit, int) Result.t
+
+val set_expr : t -> string -> (unit, int) Result.t
+
+val set_tuple : t -> Stream.t -> (unit, int) Result.t
+
+val set_ops : t -> Stream.t -> (unit, int) Result.t
+
+val compile : Stream.t -> t -> int64
+
+val select : unit -> t
+
+val insert : unit -> t
+
+val replace : unit -> t
+
+val update : unit -> t
+
+val delete : unit -> t
+
+val auth : unit -> t
+
+val eval : unit -> t
+
+val call : unit -> t
+
+val call_16 : unit -> t
+
+val upsert : unit -> t
+
+val ping : unit -> t
+
+type c_t
+
+val c_t : c_t Ctypes.typ
+
+val c : t -> c_t Ctypes_static.ptr

--- a/lib/tnt/tnt.ml
+++ b/lib/tnt/tnt.ml
@@ -1,3 +1,4 @@
 module Opt = Opt
 module Reply = Reply
+module Request = Request
 module Stream = Stream

--- a/lib/tnt/tnt.mli
+++ b/lib/tnt/tnt.mli
@@ -1,3 +1,4 @@
 module Opt = Opt
 module Reply = Reply
+module Request = Request
 module Stream = Stream


### PR DESCRIPTION
This patch adds `tnt_request` bindings of Tarantool-C library. This class is used to form Tarantool requests.